### PR TITLE
Signal custom conditions on unknown fields

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,6 @@
 .onUnload <- function (libpath) { # nocov start
   gc() # Force garbage collection of connections
   library.dynam.unload("odbc", libpath)
-} # nocov end
+}
+
+# nocov end

--- a/src/condition.h
+++ b/src/condition.h
@@ -1,0 +1,36 @@
+#ifndef CONDITION_H_
+#define CONDITION_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <Rinternals.h>
+
+static SEXP signal_condition(const char * msg, const char * class_, SEXP env = R_GlobalEnv) {
+  SEXP condition, c, signalConditionFun, out;
+
+  condition = PROTECT(Rf_mkNamed(VECSXP, (const char *[]) { "message", ""}));
+
+  PROTECT(c = Rf_allocVector(STRSXP, 2));
+  SET_STRING_ELT(c, 0, Rf_mkChar(class_));
+  SET_STRING_ELT(c, 1, Rf_mkChar("condition"));
+
+  SET_VECTOR_ELT(condition, 0, Rf_mkString(msg));
+  Rf_setAttrib(condition, R_ClassSymbol, c);
+  signalConditionFun = Rf_findFun(Rf_install("signalCondition"), R_BaseEnv);
+
+  SEXP call = PROTECT(Rf_lang2(signalConditionFun, condition));
+  out = Rf_eval(call, env);
+
+  UNPROTECT(3);
+
+  return out;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONDITION_H_ */

--- a/src/condition.h
+++ b/src/condition.h
@@ -11,7 +11,8 @@ extern "C"
 static SEXP signal_condition(const char * msg, const char * class_, SEXP env = R_GlobalEnv) {
   SEXP condition, c, signalConditionFun, out;
 
-  PROTECT(condition = Rf_mkNamed(VECSXP, (const char *[]) { "message", ""}));
+  const char *nms[] = {"message", ""};
+  PROTECT(condition = Rf_mkNamed(VECSXP, nms));
 
   PROTECT(c = Rf_allocVector(STRSXP, 2));
   SET_STRING_ELT(c, 0, Rf_mkChar(class_));
@@ -22,9 +23,9 @@ static SEXP signal_condition(const char * msg, const char * class_, SEXP env = R
   signalConditionFun = Rf_findFun(Rf_install("signalCondition"), R_BaseEnv);
 
   SEXP call = PROTECT(Rf_lang2(signalConditionFun, condition));
-  out = Rf_eval(call, env);
+  PROTECT(out = Rf_eval(call, env));
 
-  UNPROTECT(3);
+  UNPROTECT(4);
 
   return out;
 }

--- a/src/condition.h
+++ b/src/condition.h
@@ -11,7 +11,7 @@ extern "C"
 static SEXP signal_condition(const char * msg, const char * class_, SEXP env = R_GlobalEnv) {
   SEXP condition, c, signalConditionFun, out;
 
-  condition = PROTECT(Rf_mkNamed(VECSXP, (const char *[]) { "message", ""}));
+  PROTECT(condition = Rf_mkNamed(VECSXP, (const char *[]) { "message", ""}));
 
   PROTECT(c = Rf_allocVector(STRSXP, 2));
   SET_STRING_ELT(c, 0, Rf_mkChar(class_));

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -2,6 +2,7 @@
 #include "nanodbc.h"
 #include "odbc_types.h"
 #include <sqlext.h>
+#include "condition.h"
 
 using namespace odbc;
 

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -5,6 +5,7 @@
 #include <Rcpp.h>
 #include "r_types.h"
 #include "odbc_connection.h"
+#include "condition.h"
 
 namespace odbc {
 
@@ -435,7 +436,10 @@ class odbc_result {
             break;
           default:
             types.push_back(string_t);
-            Rcpp::warning("Unknown field type (%s) in column %s", type, r.column_name(i));
+
+            char buf[100];
+            sprintf(buf, "Unknown field type (%i) in column %s", type, r.column_name(i).c_str());
+            signal_condition(buf, "odbc_unknown_field_type");
             break;
         }
       }
@@ -474,7 +478,9 @@ class odbc_result {
             case logical_t: assign_logical(out, row, col, r); break;
             case raw_t: assign_raw(out, row, col, r); break;
             default:
-                            Rcpp::warning("Unknown field type (%s) in column %s", types[col], r.column_name(col));
+              char buf[100];
+              sprintf(buf, "Unknown field type (%i) in column %s", types[col], r.column_name(col).c_str());
+              signal_condition(buf, "odbc_unknown_field_type");
           }
         }
 

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -9,6 +9,11 @@
 
 namespace odbc {
 
+  inline void signal_unknown_field_type(short type, const std::string& name) {
+    char buf[100];
+    sprintf(buf, "Unknown field type (%i) in column (%s)", type, name.c_str());
+    signal_condition(buf, "odbc_unknown_field_type");
+  }
 
 class odbc_error : public std::runtime_error {
   public:
@@ -436,10 +441,7 @@ class odbc_result {
             break;
           default:
             types.push_back(string_t);
-
-            char buf[100];
-            sprintf(buf, "Unknown field type (%i) in column %s", type, r.column_name(i).c_str());
-            signal_condition(buf, "odbc_unknown_field_type");
+            signal_unknown_field_type(type, r.column_name(i));
             break;
         }
       }
@@ -477,10 +479,7 @@ class odbc_result {
             case string_t: assign_string(out, row, col, r); break;
             case logical_t: assign_logical(out, row, col, r); break;
             case raw_t: assign_raw(out, row, col, r); break;
-            default:
-              char buf[100];
-              sprintf(buf, "Unknown field type (%i) in column %s", types[col], r.column_name(col).c_str());
-              signal_condition(buf, "odbc_unknown_field_type");
+            default: signal_unknown_field_type(types[col], r.column_name(col)); break;
           }
         }
 


### PR DESCRIPTION
Rather than throwing a warning.

They can be caught with
  withCallingHandlers(expr, odbc_unknown_field_type = function(e) {...} )

Fixes #26