### PR TITLE
Readme.Rmd: Minor fixes of typos, unclear semantics and unwanted R code chunk output

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -60,7 +60,7 @@ to appear in `odbc::odbcListDrivers()`.
 
 ### Windows
 Windows is bundled with ODBC libraries however drivers for each database
-need to be installed separately. Windows ODBC drivers typically include a
+need to be installed separately. Windows ODBC drivers typically include an
 installer that needs to be run and will install the driver to the proper
 locations.
 
@@ -124,8 +124,8 @@ devtools::install_github("rstats-db/odbc")
 ```
 
 ## Connecting to a Database
-Databases can be connect by specifying a connection string directly, or with
-DSN Configuration files.
+Databases can be connected by specifying a connection string directly, or with
+DSN configuration files.
 
 ### Connection Strings
 
@@ -167,11 +167,12 @@ application is used to manage ODBC data sources on Windows.
 
 #### MacOS / Linux
 On MacOS and Linux there are two separate text files that need to be edited.
-UnixODBC includes an command line executable `odbcinst` which can be used to
+UnixODBC includes a command line executable `odbcinst` which can be used to
 query and modify the DSN files. However these are plain text files you
 can also edit by hand if desired.
 
 There are two different files used to setup the DSN information.
+
 - `odbcinst.ini` - which defines driver options
 - `odbc.ini` - which defines connection options
 
@@ -216,12 +217,12 @@ Database=/tmp/testing
 See also: [unixODBC without the GUI](http://www.unixodbc.org/odbcinst.html) for more information and examples.
 
 ## Usage
-All of the following examples assume you have already created a query `con`.
+All of the following examples assume you have already created a connection `con`.
 See [Connecting to a database](#connecting-to-a-database) for more information on establishing a
 connection.
 
 ### Table and Field information
-`dbListTables()` is used for listing tables in a database.
+`dbListTables()` is used for listing all existing tables in a database.
 ```r
 dbListTables(con)
 
@@ -247,7 +248,7 @@ data <- dbWriteTable(con, "iris", iris)
 ### Querying
 `dbGetQuery()` will submit a query and fetch the results. It is also possible
 to submit the query and fetch separately with `dbSendQuery()` and `dbFetch()`.
-If the `n=` argument to `dbFetch()` can be used to fetch only part of a query.
+The `n=` argument to `dbFetch()` can be used to fetch only the part of a query result (the next *n* rows).
 ```r
 result <- dbSendQuery(con, "SELECT flight, tailnum, origin FROM flights ORDER BY origin")
 
@@ -260,12 +261,13 @@ rest <- dbFetch(result)
 
 ## Benchmarks
 
-Odbc is often much faster than the existing
+The *odbc* package is often much faster than the existing
 [RODBC](https://cran.r-project.org/package=RODBC) and DBI compatible
 [RODBCDBI](https://cran.r-project.org/package=RODBCDBI) packages.
 
 ### Reading
-Reading a from a PostgreSQL database with the nytflights13 'flights' database (336,776 rows, 19 columns).
+
+Reading a table from a PostgreSQL database with the 'flights' dataset (336,776 rows, 19 columns) of the package [nytflights13](https://github.com/hadley/nycflights13).
 ```{r, cache = TRUE}
 # First using RODBC / RODBCDBI
 library(DBI)
@@ -284,9 +286,11 @@ identical(dim(rodbc_result), dim(odbc_result))
 rm(rodbc_result, odbc_result, odbc, rodbc)
 gc(verbose = FALSE)
 ```
+
 ### Writing
+
 Writing the same dataset to the database.
-```{r, echo = FALSE, cache = TRUE}
+```{r, echo = FALSE, results = "hide", cache = TRUE}
 odbc <- dbConnect(odbc::odbc(), dsn = "PostgreSQL")
 if (dbExistsTable(odbc, "flights2")) { dbRemoveTable(odbc, "flights2") }
 if (dbExistsTable(odbc, "flights3")) { dbRemoveTable(odbc, "flights3") }


### PR DESCRIPTION
I have **NOT** checked-in the README.md file (must be generated by the package maintainer due to embedded R code with database dependencies)