### PR TITLE
FIX: dbSendStatement should NOT call result_execute

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -111,7 +111,6 @@ setMethod(
   "dbSendStatement", c("OdbcConnection", "character"),
   function(conn, statement, ...) {
     res <- OdbcResult(connection = conn, statement = statement)
-    result_execute(res@ptr)
     res
   })
 


### PR DESCRIPTION
According to DBI specification, results are executed when **dbBind** or **dbGetRowsAffected** is called. Executing results in **dbSendStatement** causes errors when parameterized queries are being sent.

The change is tested successfully against SQL Server.