### PR TITLE
Add support for previewing objects in non-default catalogs

### DIFF
--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -84,8 +84,8 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # if no catalog was supplied but this database has catalogs, return a list of
   # catalogs
   if (is.null(catalog)) {
-    catalogs <- string_values(connection_sql_tables(connection@ptr, catalog_name = catalog %||% "%", "", "", NULL)[["table_catalog"]])
-    if (length(catalogs) > 1) {
+    catalogs <- connection_sql_tables(connection@ptr, catalog_name = catalog %||% "%", "", "", NULL)[["table_catalog"]]
+    if (length(catalogs) > 1 && any(nzchar(catalogs))) {
       return(
         data.frame(
           name = catalogs,
@@ -98,8 +98,8 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # if no schema was supplied but this database has schema, return a list of
   # schema
   if (is.null(schema)) {
-    schemas <- string_values(connection_sql_tables(connection@ptr, "", schema_name = schema %||% "%", "", NULL)[["table_schema"]])
-    if (length(schemas)) {
+    schemas <- connection_sql_tables(connection@ptr, "", schema_name = schema %||% "%", "", NULL)[["table_schema"]]
+    if (length(schemas) > 1 && any(nzchar(schemas))) {
       return(
         data.frame(
           name = schemas,

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -84,7 +84,7 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # if no catalog was supplied but this database has catalogs, return a list of
   # catalogs
   if (is.null(catalog)) {
-    catalogs <- connection_sql_tables(connection@ptr, catalog_name = catalog %||% "%", "", "", NULL)[["table_catalog"]]
+    catalogs <- string_values(connection_sql_tables(connection@ptr, catalog_name = catalog %||% "%", "", "", NULL)[["table_catalog"]])
     if (length(catalogs) > 1 && any(nzchar(catalogs))) {
       return(
         data.frame(
@@ -99,7 +99,7 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # schema
   if (is.null(schema)) {
     schemas <- string_values(connection_sql_tables(connection@ptr, "", schema_name = schema %||% "%", "", NULL)[["table_schema"]])
-    if (length(schemas)) {
+    if (length(schemas) > 1 && any(nzchar(schemas))) {
       return(
         data.frame(
           name = schemas,

--- a/R/Viewer.R
+++ b/R/Viewer.R
@@ -85,7 +85,7 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # catalogs
   if (is.null(catalog)) {
     catalogs <- string_values(connection_sql_tables(connection@ptr, catalog_name = catalog %||% "%", "", "", NULL)[["table_catalog"]])
-    if (length(catalogs) > 1 && any(nzchar(catalogs))) {
+    if (length(catalogs) > 1) {
       return(
         data.frame(
           name = catalogs,
@@ -99,7 +99,7 @@ odbcListObjects.OdbcConnection <- function(connection, catalog = NULL, schema = 
   # schema
   if (is.null(schema)) {
     schemas <- string_values(connection_sql_tables(connection@ptr, "", schema_name = schema %||% "%", "", NULL)[["table_schema"]])
-    if (length(schemas) > 1 && any(nzchar(schemas))) {
+    if (length(schemas) > 1) {
       return(
         data.frame(
           name = schemas,


### PR DESCRIPTION
This change makes it possible to preview objects in catalogs other than the default; when a catalog is supplied, it's appended to the name of the object. 