### PR TITLE
Allow specifying dbms.name

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -21,6 +21,7 @@ OdbcConnection <- function(
   database = NULL,
   uid = NULL,
   pwd = NULL,
+  dbms.name = NULL,
   .connection_string = NULL) {
 
   args <- c(dsn = dsn, driver = driver, server = server, database = database, uid = uid, pwd = pwd, list(...))
@@ -34,6 +35,9 @@ OdbcConnection <- function(
   quote <- connection_quote(ptr)
 
   info <- connection_info(ptr)
+  if (!is.null(dbms.name)) {
+    info$dbms.name <- dbms.name
+  }
   class(info) <- c(info$dbms.name, "driver_info", "list")
 
   class <- getClassDef(info$dbms.name, where = class_cache, inherits = FALSE)


### PR DESCRIPTION
I'd like to allow specifying `dbms.name` to `OdbcConnection()`.

### Issue Description and Expected Result
`dbConnect()` occurs an error.

### Database
Teradata 15.10.05.03
ODBC Driver for Teradata: 15.10.01.06
macOS Sierra 10.12.6

### Reproducible Example
```r
library(odbc)
con <- dbConnect(odbc::odbc(),
                 driver = "Teradata",
                 uid = "uid",
                 pwd = "pwd",
                 DBCName = "host",
                 port = 1025)
```

```
Error in .getClassesFromCache(Class) : 
  attempt to use zero-length variable name
```

```
> traceback()
7: .getClassesFromCache(Class)
6: getClassDef(Class, where)
5: setClass(info$dbms.name, contains = "OdbcConnection", where = class_cache) at Connection.R#45
4: OdbcConnection(dsn = dsn, ..., timezone = timezone, encoding = encoding, 
       bigint = bigint, driver = driver, server = server, database = database, 
       uid = uid, pwd = pwd, .connection_string = .connection_string) at Driver.R#88
...
```

The cause seems to be that `info$dbms.name` is an empty character.

```r
connection_string <- "driver=Teradata;uid=uid;pwd=pwd;DBCName=host;port=1025;"
ptr <- odbc:::odbc_connect(connection_string, timezone = "UTC", encoding = "", bigint = 0L)
info <- odbc:::connection_info(ptr)
info
```

```
$dbname
[1] ""

$dbms.name
[1] ""

$db.version
[1] ""

$username
[1] ""

$host
[1] ""

$port
[1] ""

$sourcename
[1] ""

$servername
[1] ""

$drivername
[1] ""

$odbc.version
[1] "03.52"

$driver.version
[1] ""

$odbcdriver.version
[1] ""

$supports.transactions
[1] FALSE
```

Therefore, if you allow setting `dbms.name`, I think that this problem will be solved.

```r
con <- dbConnect(odbc::odbc(),
                 driver = "Teradata",
                 uid = "kmakiyam",
                 pwd = "a78dfbca3",
                 DBCName = "gw6690.tera.kks.yahoo.co.jp",
                 port = 1025,
                 dbms.name = "Teradata")
dbGetQuery(con, "select * from dbc.dbcinfo;")
```

```
                InfoKey    InfoData
1               VERSION 15.10.05.03
2 LANGUAGE SUPPORT MODE    Japanese
3               RELEASE 15.10.05.03
```

Could you give me any advice?

<details>
<summary>Session Info</summary>

```r
devtools::session_info()
Session info --------------------------------------------------------------------------------------
 setting  value                       
 version  R version 3.4.1 (2017-06-30)
 system   x86_64, darwin15.6.0        
 ui       RStudio (1.0.153)           
 language (EN)                        
 collate  ja_JP.UTF-8                 
 tz       Asia/Tokyo                  
 date     2017-10-03                  

Packages ------------------------------------------------------------------------------------------
 package   * version date       source         
 base      * 3.4.1   2017-07-07 local          
 bit         1.1-12  2014-04-09 CRAN (R 3.4.0) 
 bit64       0.9-7   2017-05-08 CRAN (R 3.4.0) 
 blob        1.1.0   2017-06-17 CRAN (R 3.4.0) 
 compiler    3.4.1   2017-07-07 local          
 datasets  * 3.4.1   2017-07-07 local          
 DBI         0.7     2017-06-18 cran (@0.7)    
 devtools    1.13.3  2017-08-02 CRAN (R 3.4.1) 
 digest      0.6.12  2017-01-27 CRAN (R 3.4.0) 
 graphics  * 3.4.1   2017-07-07 local          
 grDevices * 3.4.1   2017-07-07 local          
 hms         0.3     2016-11-22 CRAN (R 3.4.0) 
 memoise     1.1.0   2017-04-21 CRAN (R 3.4.0) 
 methods   * 3.4.1   2017-07-07 local          
 odbc      * 1.1.2   2017-10-03 local          
 Rcpp        0.12.12 2017-07-15 cran (@0.12.12)
 rlang       0.1.2   2017-08-09 cran (@0.1.2)  
 stats     * 3.4.1   2017-07-07 local          
 tibble      1.3.4   2017-08-22 cran (@1.3.4)  
 tools       3.4.1   2017-07-07 local          
 utils     * 3.4.1   2017-07-07 local          
 withr       2.0.0   2017-07-28 CRAN (R 3.4.1) 
```
</details>