### PR TITLE
Fix forgetting negation

### DIFF
--- a/R/Connection.R
+++ b/R/Connection.R
@@ -38,7 +38,7 @@ OdbcConnection <- function(
   if (!is.null(dbms.name)) {
     info$dbms.name <- dbms.name
   }
-  if (nzchar(info$dbms.name)) {
+  if (!nzchar(info$dbms.name)) {
     stop("The ODBC driver returned an invalid `dbms.name`. Please provide one manually with the `dbms.name` parameter.", call. = FALSE)
   }
   class(info) <- c(info$dbms.name, "driver_info", "list")


### PR DESCRIPTION
You might forget negation.

```r
> nzchar("")
[1] FALSE
> nzchar("something")
[1] TRUE
```